### PR TITLE
Adds restart options so that if postgres web client loses the race co…

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,5 +1,5 @@
-FROM postgres
-MAINTAINER mkalish
+FROM postgres:9.5
+LABEL maintainer "codefordc"
 
 
 COPY ./init-data.sh /docker-entrypoint-initdb.d/init-data.sh

--- a/postgres/docker-compose.yml
+++ b/postgres/docker-compose.yml
@@ -7,6 +7,9 @@ services:
             - POSTGRES_PASSWORD=codefordc
             - POSTGRES_USER=codefordc
             - POSTGRES_DB=codefordc
+        ports:
+            - "5432:5432"
+        restart: "on-failure:3"
     web:
         image: sosedoff/pgweb
         environment:
@@ -15,3 +18,4 @@ services:
             - postgres
         ports:
             - "8081:8081"
+        restart: "on-failure:10"


### PR DESCRIPTION
…ndition, it will be restarted.

Specifies Postgres 9.5 as a demo of how to make sure to use a specific version of Postgres. 9.5 is most recent version that runs on AWS (9.6 is most recent available).