### PR TITLE
Add changes from Housing Insights to this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,40 @@
 # Project Management
 
+This repo provides boilerplate project code to help jumpstart new projects. To date, we have focused on
+setting up Docker images for projects to help speed up their onboarding process. 
+
+## Folders
+Each folder contains relevant Dockerfiles and code for setting up that particular tool or language
+within a Docker container. See each folder for more detailed information
+
+## Docker Compose
+Since many projects may need more than one software, it is often useful to run the containers using
+a single docker-compose file. Even if you need only one container, you can still use docker-compose. 
+As such, you should usually try running the images using docker-compose as your first approach. 
+
+This root folder contains a single `docker-compose.yml` file that is configured for the structure
+of this project management repository. To get started using this file, you can copy the file into 
+your project and delete the sections that you don't need. Many of the sections of compose, however,
+expect this folder structure and expect to find the `Dockerfile`s that are located in each of the 
+subfolders. When this is the case, look for the 'context' setting, which specifies the subfolder
+where docker-compose will look for these files. Copy any appropriate `Dockerfile` into a subfolder
+of your project, and then edit the `context` to match the name. 
+
+For example, if you wanted to use the Python Docker image, and wanted to store your Python code
+in a folder of your project called `src`, you would:
+- Copy the `Dockerfile` and `environment.yml` from the /python folder into your /src folder
+- Edit the relevant portion of `docker-compose.yml` to look like this:
+
+    ```
+    sandbox:
+        build:
+            context: src #used to be python
+    ```
+
+To run the docker-compose file and build/start all the containers listed in it, use:
+* `docker-compose up -d` to start in detached mode (containers run in the background)
+* `docker-compose stop` to end the processes
+
 ## Notes on Docker
 Please make sure to grab the most recent Docker Communitiy Edition for your operating system*.
 
@@ -13,13 +48,19 @@ Please use [docker toolbox](https://docs.docker.com/toolbox/overview/)
 ## Logging into Docker Hub
 If you don't already have an account you can register for one at [Docker Hub](https://hub.docker.com/).
 
-To login run: `docker login` and follow the prompts.  You are no logged in!
+To login run: `docker login` and follow the prompts.
 
 ## Publishing Images
 Once you have built the image you would like to publish, run `docker publish codefordc2/{youimage}`
 
-
 ## Docker Toolbox
 Windows Home edition does not support docker natively, so VirtualBox is used to create an environment for the docker daemon. [Here](https://docs.docker.com/machine/install-machine/)
 
-<strong>Note:</strong> The other READMEs will always refer to the IP address to use as `localhost` or `127.0.0.1`.  When using docker-machine you will need to use the IP address of the virtual machine.  To do so run `docker-machine ip
+<strong>Note:</strong> The other READMEs will always refer to the IP address to use as `localhost` or `127.0.0.1`.  When using docker-machine you will need to use the IP address of the virtual machine.  To do so run `docker-machine ip`
+
+## Other useful commands
+
+* `docker ps` lists all running containers
+* `docker-compose up` starts all containers in the docker-compose.yml file. Add ` -d` to run in detached mode (get your command prompt back)
+* `docker-compose stop` stops running containers
+* `docker-compose down` then `docker-compose build` rebuilds containers from scratch (useful if one gets corrupted, if you change settings such as in the Python environment.yml file)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '2'
+
+services:
+
+
+    jekyll:
+        build:
+            context: jekyll/docs
+        command:
+            - jekyll serve --watch --incremental --force_polling
+        volumes:
+            - ./jekyll/docs:/srv/jekyll
+        ports:
+            - "4000:4000"
+
+    web:
+        image: sosedoff/pgweb
+        environment:
+            - DATABASE_URL=postgres://codefordc:codefordc@postgres:5432/codefordc_postgres_docker?sslmode=disable
+        links:
+            - postgres
+        ports:
+            - "8081:8081"
+        restart: "on-failure:10"
+
+    postgres:
+        #housing-insights-postgres is an empty Postgres 9.5 install
+        image: codefordc2/housing-insights-postgres
+        environment:
+            - POSTGRES_PASSWORD=codefordc
+            - POSTGRES_USER=codefordc
+            - POSTGRES_DB=codefordc_postgres_docker
+        ports:
+            - "5432:5432"
+        restart: "on-failure:3"
+
+    sandbox:
+        build:
+            context: python
+        volumes:
+            - .:/repo
+        command: tail -f /dev/null
+        ports:
+            - "5000:5000"
+        environment:
+            - SET_CONTAINER_TIMEZONE=true
+            - CONTAINER_TIMEZONE=America/New_York

--- a/jekyll/Dockerfile
+++ b/jekyll/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /srv/jekyll
 
 RUN bundle install
 
-ENTRYPOINT ["bundle", "exec", "jekyll", "serve", "-w", "--host", "0.0.0.0"]
+ENTRYPOINT ["bundle", "exec", "jekyll", "serve", "--host", "0.0.0.0", "--watch", "--incremental", "--force_polling"]
 
 EXPOSE 4000
 

--- a/jekyll/README.md
+++ b/jekyll/README.md
@@ -11,19 +11,14 @@ excellent tool for generating complicated static sites out of markdown and html.
 into github pages which means they handle the work of generating the site and serving it, making it great,
 free tool for projects.  For more information vist [jekyll's documentatin](https://jekyllrb.com/)
 
-## Project Structure
-
-This directory contains two different Dockerfiles; one serves to build a container that operates as a one liner
-for generating a new jekyll site from scratch in the directory of your choosing.  The other image is 
-setup to serve a jekyll site with a passed in directory of where the site lives.
-
-### Builder
-
 Jekyll is written in ruby and built using bundler and though jekyll is incredibly easy to work with, these 
 tools sometimes are not.  Different versions of ruby, wrong installation directory for gems and incorrect sudo
-use can all cause errors when trying to install jekyll and build a new site.  This image takes all that
-hard work out for you by relying on a docker image that when run will generate the site.
+use can all cause errors when trying to install jekyll, build and edit a site. This directory contains two different
+Dockerfiles; one is used to generate a new jekyll site from scratch in the directory of your choosing.  The other image
+lets you view an existing Jekyll site in your browser as you edit it. 
 
+### Builder
+If you don't have a Jekyll site yet, jumpstart your project by building one from this image. 
 The image has been published here https://hub.docker.com/r/codefordc2/jekyll-starter/ so that you 
 do not have to build it locally.
 
@@ -46,27 +41,31 @@ the repository's setting page on github.com.  In the _Github Pages_ section, set
 
 #### Serving
 
-The second image in this directory is one that can help serving jekyll with the live reloading.  There are
-two options for using it.
+The second image is used for running an existing Jekyll site in your browser (such as the one you just built), and regenerating the site any time you save changes to the code. 
+    1. Copy `jekyll/Dockerfile` into the root of your repository where the jekyll site was installed
+    2. Run `docker build . -t {jekyll_mysite}` (substitute the name of your repository for 'mysite')
+    3. Run `docker-machine ip`. Make a note of this ip address (often something like 192.168.99.100). 
+    3. Run `docker run --volume $(pwd)/docs:/srv/jekyll -p 4000:4000 {jekyll_mysite}`
+    4. You're site will now be running and you can access it at http://{your-ip}:4000 (substituting the ip from step 3). 
 
-1. If your jekyll site is using additional gem plugins, you can use the docker file and build your own image.
-    1. Copy `jekyll/Dockerfile` into the root of your repository repository where the jekyll site was installed
-    2. Run `docker build . -t codefordc2/{mysite}` (substitute the name of your repository)
-    3. Run `docker run --volume $(pwd)/docs:/srv/jekyll -p  127.0.0.1:4000:4000 codefordc2/{mysite}`
-    4. You're site will now be running and you can access it at http://127.0.0.1:4000 and all changes will be live reloaded
-    - If you have issues installing gems, one possible solution is to add source 'https://rubygems.org' to your Gemfile
+When you save a file, the website will be rebuilt and you can view the changes by refreshing the page. Unfortunately, depending on which operating system you're using and which version of Docker you have, Docker is sometimes much slower to recognize changes to files and execute the rebuild. This can make it much more inefficient to use Docker for day-to-day development. To make sure that your changes are being reloaded, you should watch the command line output of the container that is running Jekyll. 
 
-2. It can be used out of the box by pulling the image.  Please note this will work only if your jekyll project is only using the vanilla install and does not rely on other plugins that would have been 
-installed via gem.  *This will most likely only work for jekyll sites created via the jekyll-builder image.*
-    1. Run `docker pull codefordc2/jekyll-serve:release`
-    2. Navigate to where you built your jekyll site
-    3. Run `docker run --volume $(pwd)/docs:/srv/jekyll -p  127.0.0.1:4000:4000 codefordc2/jekyll-serve`
-    4. You're site will now be running and you can access it at http://127.0.0.1:4000 and all changes will be live reloaded
+When you save a file, watch the command prompt to see when the changes are reflected - note that refreshing the page in your browser will not show the changes until the `done in XX seconds.` portion of the message is shown. 
 
+**If you are using docker-compose or docker run in detached mode (`-d`)**
+In this case, you'll need to do some steps to see the output of the Jekyll container:
 
-
-
-
+    5. Run `docker ps` to view a list of the currently running containers. You should see something like this:
+        ```
+        CONTAINER ID        IMAGE               ...  PORTS                    NAMES
+        6767fbc67457        jekyll_mysite       ...  0.0.0.0:4000->4000/tcp   jekyll_mysite_1
+        ```
+    6. Find the name of the jekyll container - in this case it is `jekyll_mysite_1`. You can also use the container id
+    7. Run `docker logs -f jekyll_mysite_1` to view the realtime output of the container. 
+    8. Visit `localhost:4000` or `<your-docker-ip>:/4000` in your web browser, where `<your-docker-ip>` is the ip address of the docker container ()
+    9. When you want your command prompt back (without stopping Docker or Jekyll), type `ctrl+c` in the terminal window. 
 
 
-
+## Notes and Troubleshooting
+- If you have long delays in running your file, you may want to [install Jekyll directly](https://jekyllrb.com/docs/installation/). 
+- If you have issues installing gems, one possible solution is to add source 'https://rubygems.org' to your Gemfile

--- a/jekyll/docs/Gemfile.lock
+++ b/jekyll/docs/Gemfile.lock
@@ -51,7 +51,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.4.0p0
+   ruby 2.4.1p111
 
 BUNDLED WITH
-   1.14.3
+   1.15.1

--- a/jekyll/docs/about.md
+++ b/jekyll/docs/about.md
@@ -13,3 +13,4 @@ You can find the source code for the Jekyll new theme at:
 You can find the source code for Jekyll at
 {% include icon-github.html username="jekyll" %} /
 [jekyll](https://github.com/jekyll/jekyll)
+

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -9,7 +9,13 @@ The second part is a sample docker-compose.yml that will serve as example of how
 an instance of the postgres database with the data and a postgres web client that can be 
 used to manipulate and query the data.
 
-## Getting started with the Postgres Dockerfile
+## Empty Database
+
+If you just want to instantiate an empty database that you can add data to afterwards, 
+(such as via a data ingestion script) you can use the docker-compose file in the root directory. 
+
+
+## Create your own Postgres image with starter data
 
 The Dockerfile in this directory extends the official postgres image.  The extension copies
 the initial data into the postgres image and when the container is started will load the 
@@ -18,7 +24,7 @@ data.
 ### Steps to get started (assumes you have access to an existing Postgres database)
 
 1. Run `pg_dump --no-owner --no-privileges -F c -f data.dump  --dbname {insert your database}`
-    - alternatively you can use the full connection string `pg_dump --no-owner --no-privileges -F c -f data.dump --dbname=postgresql://postgres:postgres@localhost:5433/housinginsights_lo`
+    - alternatively you can use the full connection string `pg_dump --no-owner --no-privileges -F c -f data.dump --dbname=postgresql://youruser:yourpassword@localhost:5432/yourdatabasename`
 2. Copy the file, `data.dump` into this directory.
 3. Run `docker build . -t codefordc2/{your-project}-postgres`
 

--- a/postgres/docker-compose.yml
+++ b/postgres/docker-compose.yml
@@ -3,17 +3,20 @@ version: '2'
 services:
     postgres:
         image: codefordc2/postgres
+
+        #If you edit these, also edit them in the matching environment string in 'web'
         environment:
-            - POSTGRES_PASSWORD=codefordc
-            - POSTGRES_USER=codefordc
-            - POSTGRES_DB=codefordc
+            - POSTGRES_PASSWORD=codefordcpassword
+            - POSTGRES_USER=codefordcuser
+            - POSTGRES_DB=codefordcdatabase
         ports:
             - "5432:5432"
         restart: "on-failure:3"
     web:
         image: sosedoff/pgweb
         environment:
-            - DATABASE_URL=postgres://codefordc:codefordc@postgres:5432/codefordc?sslmode=disable
+            #here 'postgres' corresponds to the service name above, and the three 'codefordcXXX' strings to the environments above.
+            - DATABASE_URL=postgres://codefordcuser:codefordcpassword@postgres:5432/codefordcdatabase?sslmode=disable
         links:
             - postgres
         ports:

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,18 @@
-FROM python:3.5
-VOLUME /usr/src/scripts
-WORKDIR /usr/src/scripts
+FROM continuumio/miniconda3
 
-ENTRYPOINT ["python"]
+# Set up code directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY environment.yml .
+
+# Install dependencies
+RUN conda env create -f environment.yml
+
+# Make sure that the environment updates appropriately (sometimes needed, doesn't hurt)
+RUN conda env update -n codefordc -f environment.yml
+
+# Activate environment
+RUN echo "export PATH=/opt/conda/envs/housing-insights/bin:$PATH" >> /root/.bashrc
+
+EXPOSE 5000

--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,42 @@
 # Code for DC Python
-This is a help file for running single python scripts
+The Docker image created by this Dockerfile provides a copy of miniconda](), a package management system 
+and environment management system that is a common way to install and use Python. It lets you specify
+any version of Python, as well as the packages you want to use with it. 
 
-The line below will execute script below.
-`docker run -it --rm -v "$PWD":/usr/src/scripts codefordc2/python-script-runner:3.5 codeofordcme.py`
+This Dockerfile automatically creates a virtual environment within the installation using the contents
+of the `environment.yml` file stored in the same directory. By adding additional Python packages 
+to the list in the environment.yml, either by exporting an environment or by editing the file directly. 
+Read about [how conda environments work here](https://conda.io/docs/user-guide/tasks/manage-environments.html).
+
+Using this image allows contributors to run Python code without installing Python, and to have an
+up-to-date copy of the virtual environment without maintaining it themselves. 
+
+## Usage
+
+Assuming you are using the docker-compose.yml file to manage this container alongside any other containers
+you may be using, you can use the following commands to run this Docker container.
+
+* From the folder that has the docker-compose.yml file (i.e. the project root directory), run `docker-compose up -d`. 
+The first time this is run, it will build and run the containers listed in the compose file, including this one. 
+
+
+* `docker-compose exec sandbox bash` allows you access to the command prompt of the docker container that is running
+the Python/miniconda instance. `sandbox` is the name specified in docker-compose - if you have edited it, change the
+command accordingly. 
+* `cd /repo` to move into the folder containing the code. Assuming that docker-compose.yml is stored in the root of 
+your project repository, this will be a copy of the whole project repo
+* `cd python` to move into the python folder
+* `python codefordcme.py` to execute the 'codefordc.py' script in this repository. You can execute any other script desired
+in the same way. 
+* press `ctrl+p` and then `ctrl+q` to exit out of the container terminal and return to your normal terminal
+* `docker-compose stop` ends all the compose processes. 
+
+## Updating environment.yml
+Any time you edit the environment.yml, you will need to tell Docker to rebuild the container image with the new packages
+installed. To do this, from the folder with the docker-compose file:
+
+* `docker-compose down`
+* `docker-compose build`
+* `docker-compose up -d`
+
+Note, you can also run conda commands for managing your virtual environment directly from within the container as well. 

--- a/python/environment.yml
+++ b/python/environment.yml
@@ -1,0 +1,7 @@
+name: codefordc
+channels:
+- defaults
+
+dependencies:
+- python=3.6
+- nose


### PR DESCRIPTION
This commit adds multiple changes that we have found to be useful in the Housing Insights project
- By default, assume that everyone will use docker-compose instead of docker run. Since docker-compose works for a single container anyways, and many users will need to combine multiple images, this can simplify the learning curve for a project manager that is dockerizing their project for the first time by just having them start with the compose file.
- Python is instead a miniconda instance that automatically builds a local virtual environment using the environment.yml file. This makes the Python image more useful.
- Rewrites the Postgres documentation to emphasize the difference between starting with an empty database vs. making a container that contains preloaded data.
- Adds --force-polling to Jekyll command to solve the problem that some systems/installs don't have autoreloading work properly (due to slow communication between container volume and local machine). Also adds documentation about how to check and make sure your system is automatically rebuilding the Jeykll site when it is served, to give users a way to know if they are victim of a very slow Jekyll rebuild instead of wondering why their code changes aren't showing up.